### PR TITLE
fix runtime error in Bolt 3.2 and above

### DIFF
--- a/templates/field_text.twig
+++ b/templates/field_text.twig
@@ -31,7 +31,7 @@
 
     <label class="col-sm-2 col-md-3 col-lg-4 control-label">{{ option.label ? option.label : name | capitalize }}</label>
     <div class="col-sm-10 col-md-9 col-lg-8">
-        <input{{ macro.attr(attr_text) }}>
+        <input{{ macro.attribute(attr_text) }}>
     </div>
 
 </fieldset>


### PR DESCRIPTION
Add `{% from '@bolt/_macro/_macro.twig' import attr %}` to the top of each of the four input field templates, then find all instances of `{{ macro.attr(attr_text) }}`, `{{ macro.attr(attr_opt) }}` and `{{ macro.attr(attr_checkbox) }}` and **delete** the `macro.` from the twig function. Leave everything else as it is, and runtime error should be fixed for Bolt 3.2 and above.