### PR TITLE
fix runtime error in Bolt 3.2 and above

### DIFF
--- a/templates/field_select.twig
+++ b/templates/field_select.twig
@@ -51,7 +51,7 @@
                     } %}
                 {% endif %}
 
-                <option{{ macro.attr(attr_opt) }}>{{ value }}</option>
+                <option{{ macro.attribute(attr_opt) }}>{{ value }}</option>
             {% endfor %}
         </select>
     </div>


### PR DESCRIPTION
Add `{% from '@bolt/_macro/_macro.twig' import attr %}` to the top of each of the four input field templates, then find all instances of `{{ macro.attr(attr_text) }}`, `{{ macro.attr(attr_opt) }}` and `{{ macro.attr(attr_checkbox) }}` and **delete** the `macro.` from the twig function. Leave everything else as it is, and runtime error should be fixed for Bolt 3.2 and above.